### PR TITLE
Fixed a bug in date parsing. GTFS specifies a format of yyyymmdd but the...

### DIFF
--- a/GTFS.Test/DirectorySourceTest.cs
+++ b/GTFS.Test/DirectorySourceTest.cs
@@ -361,13 +361,6 @@ namespace GTFS.Test
         {
             // create the reader.
             GTFSReader<GTFSFeed> reader = new GTFSReader<GTFSFeed>();
-            reader.DateTimeReader = (dateString) =>
-            {
-                var year = int.Parse(dateString.Substring(0, 4));
-                var month = int.Parse(dateString.Substring(4, 2));
-                var day = int.Parse(dateString.Substring(6, 2));
-                return new System.DateTime(year, month, day);
-            };
 
             // build the source
             var source = this.BuildSource();
@@ -415,13 +408,6 @@ namespace GTFS.Test
         {
             // create the reader.
             GTFSReader<GTFSFeed> reader = new GTFSReader<GTFSFeed>();
-            reader.DateTimeReader = (dateString) =>
-            {
-                var year = int.Parse(dateString.Substring(0, 4));
-                var month = int.Parse(dateString.Substring(4, 2));
-                var day = int.Parse(dateString.Substring(6, 2));
-                return new System.DateTime(year, month, day);
-            };
 
             // build the source
             var source = this.BuildSource();

--- a/GTFS/GTFSReader.cs
+++ b/GTFS/GTFSReader.cs
@@ -49,7 +49,7 @@ namespace GTFS
 
             this.DateTimeReader = (dateString) =>
                 {
-                    return DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+                    return DateTime.ParseExact(dateString, "yyyyMMdd", System.Globalization.CultureInfo.InvariantCulture);
                 };
             this.DateTimeWriter = (date) =>
                 {


### PR DESCRIPTION
Fixed a bug in date parsing. GTFS specifies a format of yyyymmdd but the existing implementation was using the invariant culture patterns. Tests were working because the test swapped out the implementation for one that worked.
