### PR TITLE
agency_id is not required in agency and routes file

### DIFF
--- a/GTFS/GTFSReader.cs
+++ b/GTFS/GTFSReader.cs
@@ -470,7 +470,7 @@ namespace GTFS
         protected virtual Agency ParseAgency(T feed, GTFSSourceFileHeader header, string[] data)
         {
             // check required fields.
-            this.CheckRequiredField(header, header.Name, this.AgencyMap, "agency_id");
+
             this.CheckRequiredField(header, header.Name, this.AgencyMap, "agency_name");
             this.CheckRequiredField(header, header.Name, this.AgencyMap, "agency_url");
             this.CheckRequiredField(header, header.Name, this.AgencyMap, "agency_timezone");
@@ -863,7 +863,7 @@ namespace GTFS
         {
             // check required fields.
             this.CheckRequiredField(header, header.Name, this.RouteMap, "route_id");
-            this.CheckRequiredField(header, header.Name, this.RouteMap, "agency_id");
+
             this.CheckRequiredField(header, header.Name, this.RouteMap, "route_short_name");
             this.CheckRequiredField(header, header.Name, this.RouteMap, "route_long_name");
             this.CheckRequiredField(header, header.Name, this.RouteMap, "route_desc");


### PR DESCRIPTION
Went to validate a GTFS feed and failed. I checked the latest specs in Google page. Looks like the field agency_id is optional for both routes.txt and agency.txt

https://developers.google.com/transit/gtfs/reference#agency_fields

https://developers.google.com/transit/gtfs/reference#routes_fields
