### PR TITLE
Do not panic on missing lat & lon

### DIFF
--- a/src/GTFS/GTFSReader.cs
+++ b/src/GTFS/GTFSReader.cs
@@ -943,7 +943,7 @@ namespace GTFS
                     route.ShortName = this.ParseFieldString(header.Name, fieldName, value);
                     break;
                 case "route_long_name":
-                    route.LongName= this.ParseFieldString(header.Name, fieldName, value);
+                    route.LongName = this.ParseFieldString(header.Name, fieldName, value);
                     break;
                 case "route_desc":
                     route.Description = this.ParseFieldString(header.Name, fieldName, value);
@@ -1076,10 +1076,12 @@ namespace GTFS
                     stop.Description = this.ParseFieldString(header.Name, fieldName, value);
                     break;
                 case "stop_lat":
-                    stop.Latitude = this.ParseFieldDouble(header.Name, fieldName, value).Value;
+                    var lat = this.ParseFieldDouble(header.Name, fieldName, value);
+                    stop.Latitude = lat.HasValue ? lat.Value : 0d;
                     break;
                 case "stop_lon":
-                    stop.Longitude = this.ParseFieldDouble(header.Name, fieldName, value).Value;
+                    var lon = this.ParseFieldDouble(header.Name, fieldName, value);
+                    stop.Longitude = lon.HasValue ? lon.Value : 0d;
                     break;
                 case "zone_id":
                     stop.Zone = this.ParseFieldString(header.Name, fieldName, value);


### PR DESCRIPTION
Sadly, the library crashed due to some missing lat and lon values. Meaning that the method in charge returned null (double?) which was not handled correctly.
I tried to parse this GTFS feed by a german provider: https://openvrr.de/dataset/gtfs