### PR TITLE
Respect strict flag on parsing non-existent or invalid lat & lon

### DIFF
--- a/src/GTFS/GTFSReader.cs
+++ b/src/GTFS/GTFSReader.cs
@@ -1077,10 +1077,22 @@ namespace GTFS
                     break;
                 case "stop_lat":
                     var lat = this.ParseFieldDouble(header.Name, fieldName, value);
+
+                    if (this._strict && lat.HasValue)
+                    {
+                        throw new GTFSParseException(header.Name, fieldName, value);
+                    }
+
                     stop.Latitude = lat.HasValue ? lat.Value : 0d;
                     break;
                 case "stop_lon":
                     var lon = this.ParseFieldDouble(header.Name, fieldName, value);
+
+                    if (this._strict && lon.HasValue)
+                    {
+                        throw new GTFSParseException(header.Name, fieldName, value);
+                    }
+
                     stop.Longitude = lon.HasValue ? lon.Value : 0d;
                     break;
                 case "zone_id":

--- a/src/GTFS/GTFSReader.cs
+++ b/src/GTFS/GTFSReader.cs
@@ -1078,7 +1078,7 @@ namespace GTFS
                 case "stop_lat":
                     var lat = this.ParseFieldDouble(header.Name, fieldName, value);
 
-                    if (this._strict && lat.HasValue)
+                    if (this._strict && !lat.HasValue)
                     {
                         throw new GTFSParseException(header.Name, fieldName, value);
                     }
@@ -1088,7 +1088,7 @@ namespace GTFS
                 case "stop_lon":
                     var lon = this.ParseFieldDouble(header.Name, fieldName, value);
 
-                    if (this._strict && lon.HasValue)
+                    if (this._strict && !lon.HasValue)
                     {
                         throw new GTFSParseException(header.Name, fieldName, value);
                     }


### PR DESCRIPTION
Saw this in another PR of this library. Might be useful.

The other PR contains a lot of useful enhancements/fixes. Might split them up and modernize them if needed?