### PR TITLE
Implement parsing of platform_code

### DIFF
--- a/src/GTFS/Entities/Stop.cs
+++ b/src/GTFS/Entities/Stop.cs
@@ -108,6 +108,12 @@ namespace GTFS.Entities
         public string WheelchairBoarding { get; set; }
 
         /// <summary>
+        /// Gets or sets the platform code. It is optional. Do not include the platform terms (e.g. platform) itself. Instead only 'A' or '1'.
+        /// </summary>
+        [FieldName("platform_code")]
+        public string PlatformCode { get; set; }
+
+        /// <summary>
         /// Returns a description of this trip.
         /// </summary>
         /// <returns></returns>
@@ -137,6 +143,7 @@ namespace GTFS.Entities
                 hash = hash * 43 + this.Url.GetHashCodeEmptyWhenNull();
                 hash = hash * 43 + this.WheelchairBoarding.GetHashCodeEmptyWhenNull();
                 hash = hash * 43 + this.Zone.GetHashCodeEmptyWhenNull();
+                hash = hash * 43 + this.PlatformCode.GetHashCodeEmptyWhenNull();
                 return hash;
             }
         }
@@ -160,7 +167,8 @@ namespace GTFS.Entities
                     (this.Timezone ?? string.Empty) == (other.Timezone ?? string.Empty) &&
                     (this.Url ?? string.Empty) == (other.Url ?? string.Empty) &&
                     (this.WheelchairBoarding ?? string.Empty) == (other.WheelchairBoarding ?? string.Empty) &&
-                    (this.Zone ?? string.Empty) == (other.Zone ?? string.Empty);
+                    (this.Zone ?? string.Empty) == (other.Zone ?? string.Empty) &&
+                    (this.PlatformCode ?? string.Empty) == (other.PlatformCode ?? string.Empty);
             }
             return false;
         }

--- a/src/GTFS/GTFSReader.cs
+++ b/src/GTFS/GTFSReader.cs
@@ -1099,6 +1099,9 @@ namespace GTFS
                 case " wheelchair_boarding ":
                     stop.WheelchairBoarding = this.ParseFieldString(header.Name, fieldName, value);
                     break;
+                case "platform_code":
+                    stop.PlatformCode = this.ParseFieldString(header.Name, fieldName, value);
+                    break;
             }
         }
 

--- a/src/GTFS/GTFSWriter.cs
+++ b/src/GTFS/GTFSWriter.cs
@@ -468,7 +468,7 @@ namespace GTFS
             if (file != null)
             {
                 bool initialized = false;
-                var data = new string[12];
+                var data = new string[13];
                 foreach (var entity in entities)
                 {
                     if (!initialized)
@@ -491,6 +491,7 @@ namespace GTFS
                         data[9] = "parent_station";
                         data[10] = "stop_timezone";
                         data[11] = "wheelchair_boarding";
+                        data[12] = "platform_code";
                         file.Write(data);
                         initialized = true;
                     }
@@ -508,6 +509,7 @@ namespace GTFS
                     data[9] = this.WriteFieldString("stops", "parent_station", entity.ParentStation);
                     data[10] = this.WriteFieldString("stops", "stop_timezone", entity.Timezone);
                     data[11] = this.WriteFieldString("stops", "wheelchair_boarding", entity.WheelchairBoarding);
+                    data[12] = this.WriteFieldString("stops", "platform_code", entity.PlatformCode);
                     file.Write(data);
                 }
                 file.Close();


### PR DESCRIPTION
The unit tests don't run on machine. Test discovery can not find/excecute them :( It worked on my local GTFS feed I am trying to work with. Also this is the behaviour I concluded from already existing fields. There is some refactoring needed to make this easier I guess. Also I think there are other missing fields as google seems to have updated the specification.

See issue #58 