### PR TITLE
Implement write field transfer type

### DIFF
--- a/src/GTFS/GTFSWriter.cs
+++ b/src/GTFS/GTFSWriter.cs
@@ -936,6 +936,18 @@ namespace GTFS
         /// <returns></returns>
         private string WriteFieldTransferType(string name, string fieldName, TransferType value)
         {
+            switch (value)
+            {
+                case TransferType.Recommended:
+                    return "0";
+                case TransferType.TimedTransfer:
+                    return "1";
+                case TransferType.MinimumTime:
+                    return "2";
+                case TransferType.NotPossible:
+                    return "3";
+            }
+
             return string.Empty;
         }
 


### PR DESCRIPTION
Sorry for all the time separated PRs ^^ I get feedback on the GTFS feeds created by the tool using this library very irregular.

There is an [unimplemented method](https://github.com/itinero/GTFS/blob/8211a608c346040d4a0cdad1d0e832fe30c5df12/src/GTFS/GTFSWriter.cs#L937) for writing the field transfer type. Is there a specific reason? I took the existing implementations of those write methods and derived the implementation provided in this PR from those.

It might be better to directly do ((int) value).ToString() but I didn't want to break the existing pattern.

EDIT: Might squash the commits as there is the commit from updating my upstream on the fork still in here, which causes no harm, but might be irritating when going through the history. I can remove that one if you want to.