### PR TITLE
Implemented new route types

### DIFF
--- a/src/GTFS/Entities/Enumerations/RouteType.cs
+++ b/src/GTFS/Entities/Enumerations/RouteType.cs
@@ -58,7 +58,15 @@ namespace GTFS.Entities.Enumerations
         /// <summary>
         /// Any rail system designed for steep inclines.
         /// </summary>
-        Funicular
+        Funicular,
+        /// <summary>
+        /// Trolleybus. Electric buses that draw power from overhead wires using poles. 
+        /// </summary>
+        Trolleybus = 11,
+        /// <summary>
+        /// Monorail. Railway in which the track consists of a single rail or a beam.
+        /// </summary>
+        Monorail = 12,
     }
 
     /// <summary>
@@ -80,8 +88,10 @@ namespace GTFS.Entities.Enumerations
             //5 - Cable Car - ?
             //6 - Gondola, Suspended cable car - 1300
             //7 - Funicular - 1400
+            //11 - Trolleybus - 800
+            //12 - Monorail - 405
 
-            switch(routeType)
+            switch (routeType)
             {
                 case RouteType.Bus:
                     return RouteTypeExtended.BusService;
@@ -99,6 +109,10 @@ namespace GTFS.Entities.Enumerations
                     return RouteTypeExtended.TelecabinService;
                 case RouteType.Funicular:
                     return RouteTypeExtended.FunicularService;
+                case RouteType.Trolleybus:
+                    return RouteTypeExtended.TrolleybusService;
+                case RouteType.Monorail:
+                    return RouteTypeExtended.Monorail;
             }
             throw new System.Exception("Cannot convert route type.");
         }

--- a/src/GTFS/GTFSFeed.cs
+++ b/src/GTFS/GTFSFeed.cs
@@ -68,7 +68,7 @@ namespace GTFS
         /// <summary>
         /// Holds the feedinfo.
         /// </summary>
-        private FeedInfo _feedInfo;
+        protected FeedInfo _feedInfo;
 
         /// <summary>
         /// Sets the feed info.

--- a/src/GTFS/GTFSReader.cs
+++ b/src/GTFS/GTFSReader.cs
@@ -1625,6 +1625,8 @@ namespace GTFS
             //5 - Cable car. Used for street-level cable cars where the cable runs beneath the car.
             //6 - Gondola, Suspended cable car. Typically used for aerial cable cars where the car is suspended from the cable.
             //7 - Funicular. Any rail system designed for steep inclines.
+            //11 - Trolleybus. Electric buses that draw power from overhead wires using poles. 
+            //12 - Monorail. Railway in which the track consists of a single rail or a beam.
 
             switch (value)
             {
@@ -1644,6 +1646,10 @@ namespace GTFS
                     return RouteType.Gondola.ToExtended();
                 case "7":
                     return RouteType.Funicular.ToExtended();
+                case "11":
+                    return RouteType.Trolleybus.ToExtended();
+                case "12":
+                    return RouteType.Gondola.ToExtended();
             }
 
             if (!int.TryParse(value, out var routeTypeValue))

--- a/src/GTFS/GTFSWriter.cs
+++ b/src/GTFS/GTFSWriter.cs
@@ -811,7 +811,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldExceptionType(string name, string fieldName, ExceptionType value)
+        protected string WriteFieldExceptionType(string name, string fieldName, ExceptionType value)
         {
             //A value of 1 indicates that service has been added for the specified date.
             //A value of 2 indicates that service has been removed for the specified date.
@@ -833,7 +833,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="dateTime"></param>
         /// <returns></returns>
-        private string WriteFieldDate(string name, string fieldName, DateTime dateTime)
+        protected string WriteFieldDate(string name, string fieldName, DateTime dateTime)
         {
             return dateTime.ToString("yyyyMMdd");
         }
@@ -845,7 +845,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldBool(string name, string fieldName, bool? value)
+        protected string WriteFieldBool(string name, string fieldName, bool? value)
         {
             if (value.HasValue)
             {
@@ -865,7 +865,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldUint(string name, string fieldName, uint? value)
+        protected string WriteFieldUint(string name, string fieldName, uint? value)
         {
             if (value.HasValue)
             {
@@ -881,7 +881,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldPaymentMethod(string name, string fieldName, PaymentMethodType value)
+        protected string WriteFieldPaymentMethod(string name, string fieldName, PaymentMethodType value)
         {
             //0 - Fare is paid on board.
             //1 - Fare must be paid before boarding.
@@ -903,7 +903,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldColor(string name, string fieldName, int? value)
+        protected string WriteFieldColor(string name, string fieldName, int? value)
         {
             return value.ToHexColorString();
         }
@@ -924,7 +924,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldDouble(string name, string fieldName, double? value)
+        protected string WriteFieldDouble(string name, string fieldName, double? value)
         {
             if (value.HasValue)
             {
@@ -940,7 +940,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldInt(string name, string fieldName, int? value)
+        protected string WriteFieldInt(string name, string fieldName, int? value)
         {
             if (value.HasValue)
             {
@@ -956,7 +956,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldLocationType(string name, string fieldName, LocationType? value)
+        protected string WriteFieldLocationType(string name, string fieldName, LocationType? value)
         {
             if (value.HasValue)
             {
@@ -978,7 +978,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldDropOffType(string name, string fieldName, DropOffType? value)
+        protected string WriteFieldDropOffType(string name, string fieldName, DropOffType? value)
         {
             if (value.HasValue)
             {
@@ -1001,7 +1001,7 @@ namespace GTFS
         /// Writes the timepoint value.
         /// </summary>
         /// <returns></returns>
-        private string WriteFieldTimepointType(string name, string fieldName, TimePointType value)
+        protected string WriteFieldTimepointType(string name, string fieldName, TimePointType value)
         {
             switch (value)
             {
@@ -1020,7 +1020,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldPickupType(string name, string fieldName, PickupType? value)
+        protected string WriteFieldPickupType(string name, string fieldName, PickupType? value)
         {
             if (value.HasValue)
             {
@@ -1043,7 +1043,7 @@ namespace GTFS
         /// Writes a timeofday.
         /// </summary>
         /// <returns></returns>
-        private string WriteFieldTimeOfDay(string name, string fieldName, TimeOfDay? value)
+        protected string WriteFieldTimeOfDay(string name, string fieldName, TimeOfDay? value)
         {
             if (!value.HasValue)
             {
@@ -1062,7 +1062,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldTransferType(string name, string fieldName, TransferType value)
+        protected string WriteFieldTransferType(string name, string fieldName, TransferType value)
         {
             switch (value)
             {
@@ -1086,7 +1086,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldAccessibilityType(string name, string fieldName, WheelchairAccessibilityType? value)
+        protected string WriteFieldAccessibilityType(string name, string fieldName, WheelchairAccessibilityType? value)
         {
             if (value.HasValue)
             {
@@ -1114,7 +1114,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldIsBidirectional(string name, string fieldName, IsBidirectional? value)
+        protected string WriteFieldIsBidirectional(string name, string fieldName, IsBidirectional? value)
         {
             if (value.HasValue)
             {
@@ -1139,7 +1139,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldPathwayMode(string name, string fieldName, PathwayMode? value)
+        protected string WriteFieldPathwayMode(string name, string fieldName, PathwayMode? value)
         {
             if (value.HasValue)
             {
@@ -1179,7 +1179,7 @@ namespace GTFS
         /// <param name="fieldName"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private string WriteFieldDirectionType(string name, string fieldName, DirectionType? value)
+        protected string WriteFieldDirectionType(string name, string fieldName, DirectionType? value)
         {
             if (value.HasValue)
             {

--- a/src/GTFS/GTFSWriter.cs
+++ b/src/GTFS/GTFSWriter.cs
@@ -200,7 +200,7 @@ namespace GTFS
                         initialized = true;
                     }
 
-                    // write agency details.
+                    // write details.
                     data[0] = this.WriteFieldString("agency", "agency_id", agency.Id);
                     data[1] = this.WriteFieldString("agency", "agency_name", agency.Name, true);
                     data[2] = this.WriteFieldString("agency", "agency_url", agency.URL);
@@ -243,7 +243,7 @@ namespace GTFS
                         initialized = true;
                     }
 
-                    // write agency details.
+                    // write details.
                     data[0] = this.WriteFieldString("calendar_dates", "service_id", entity.ServiceId);
                     data[1] = this.WriteFieldDate("calendar_dates", "date", entity.Date);
                     data[2] = this.WriteFieldExceptionType("calendar_dates", "exception_type", entity.ExceptionType);
@@ -288,7 +288,7 @@ namespace GTFS
                         initialized = true;
                     }
 
-                    // write agency details.
+                    // write details.
                     data[0] = this.WriteFieldString("calendar", "service_id", entity.ServiceId);
                     data[1] = this.WriteFieldBool("calendar", "monday", entity.Monday);
                     data[2] = this.WriteFieldBool("calendar", "tuesday", entity.Tuesday);
@@ -337,7 +337,7 @@ namespace GTFS
                         initialized = true;
                     }
 
-                    // write agency details.
+                    // write details.
                     data[0] = this.WriteFieldString("fare_attributes", "fare_id", entity.FareId);
                     data[1] = this.WriteFieldString("fare_attributes", "price", entity.Price);
                     data[2] = this.WriteFieldString("fare_attributes", "currency_type", entity.CurrencyType);
@@ -381,7 +381,7 @@ namespace GTFS
                         initialized = true;
                     }
 
-                    // write agency details.
+                    // write details.
                     data[0] = this.WriteFieldString("fare_rules", "fare_id", entity.FareId);
                     data[1] = this.WriteFieldString("fare_rules", "route_id", entity.RouteId);
                     data[2] = this.WriteFieldString("fare_rules", "origin_id", entity.OriginId);
@@ -422,7 +422,7 @@ namespace GTFS
                     initialized = true;
                 }
 
-                // write agency details.
+                // write details.
                 data[0] = this.WriteFieldString("feed_info", "feed_publisher_name", entity.PublisherName, true);
                 data[1] = this.WriteFieldString("feed_info", "feed_publisher_url", entity.PublisherUrl, true);
                 data[2] = this.WriteFieldString("feed_info", "feed_lang", entity.Lang);
@@ -464,7 +464,7 @@ namespace GTFS
                         initialized = true;
                     }
 
-                    // write agency details.
+                    // write details.
                     data[0] = this.WriteFieldString("frequency", "trip_id", entity.TripId);
                     data[1] = this.WriteFieldString("frequency", "start_time", entity.StartTime);
                     data[2] = this.WriteFieldString("frequency", "end_time", entity.EndTime);
@@ -510,7 +510,7 @@ namespace GTFS
                         initialized = true;
                     }
 
-                    // write agency details.
+                    // write details.
                     data[0] = this.WriteFieldString("routes", "route_id", entity.Id);
                     data[1] = this.WriteFieldString("routes", "agency_id", entity.AgencyId);
                     data[2] = this.WriteFieldString("routes", "route_short_name", entity.ShortName, true);
@@ -556,7 +556,7 @@ namespace GTFS
                         initialized = true;
                     }
 
-                    // write agency details.
+                    // write details.
                     data[0] = this.WriteFieldString("shapes", "shape_id", entity.Id);
                     data[1] = this.WriteFieldDouble("shapes", "shape_pt_lat", entity.Latitude);
                     data[2] = this.WriteFieldDouble("shapes", "shape_pt_lon", entity.Longitude);
@@ -607,7 +607,7 @@ namespace GTFS
                         initialized = true;
                     }
 
-                    // write agency details.
+                    // write details.
                     data[0] = this.WriteFieldString("stops", "stop_id", entity.Id);
                     data[1] = this.WriteFieldString("stops", "stop_code", entity.Code);
                     data[2] = this.WriteFieldString("stops", "stop_name", entity.Name, true);
@@ -663,7 +663,7 @@ namespace GTFS
                         initialized = true;
                     }
 
-                    // write agency details.
+                    // write details.
                     data[0] = this.WriteFieldString("stop_times", "trip_id", entity.TripId);
                     data[1] = this.WriteFieldTimeOfDay("stop_times", "arrival_time", entity.ArrivalTime);
                     data[2] = this.WriteFieldTimeOfDay("stop_times", "departure_time", entity.DepartureTime);
@@ -709,7 +709,7 @@ namespace GTFS
                         initialized = true;
                     }
 
-                    // write agency details.
+                    // write details.
                     data[0] = this.WriteFieldString("transfers", "from_stop_id", entity.FromStopId);
                     data[1] = this.WriteFieldString("transfers", "to_stop_id", entity.ToStopId);
                     data[2] = this.WriteFieldTransferType("transfers", "transfer_type", entity.TransferType);
@@ -754,7 +754,7 @@ namespace GTFS
                         initialized = true;
                     }
 
-                    // write agency details.
+                    // write details.
                     data[0] = this.WriteFieldString("trips", "trip_id", entity.Id);
                     data[1] = this.WriteFieldString("trips", "route_id", entity.RouteId);
                     data[2] = this.WriteFieldString("trips", "service_id", entity.ServiceId);


### PR DESCRIPTION
This PR contributes 3 improvements:
- adds two new route types from Google's reference
- fixes some typos
- changes some access modifiers to protected to help extensions

As I was trying to to extended the GTFSWriter class to be able to write some custom GTFS entities, I realize some methods were not accessible to the children classes like `WriteFieldDouble`. If this class is open to extension, for example by overwriting the `Write` method, then the children would need these utility classes as well, therefore.