### PR TITLE
Fixed an issue with agency_fare_url not being parsed.

### DIFF
--- a/src/GTFS/GTFSReader.cs
+++ b/src/GTFS/GTFSReader.cs
@@ -719,6 +719,9 @@ namespace GTFS
                 case "agency_email":
                     agency.Email = this.ParseFieldString(header.Name, fieldName, value);
                     break;
+                case "agency_fare_url":
+                    agency.FareURL = this.ParseFieldString(header.Name, fieldName, value);
+                    break;
             }
         }
 


### PR DESCRIPTION
agency_fare_url was not being read from GTFS feeds, tested with multiple feeds that contained this data and this field was always read as null. Modified GTFSReader to parse that field as it had been missed. This would fix issue #70 