### PR TITLE
Escape quotes in CSV value fields.

### DIFF
--- a/src/GTFS/GTFSWriter.cs
+++ b/src/GTFS/GTFSWriter.cs
@@ -793,6 +793,7 @@ namespace GTFS
         /// <returns></returns>
         protected virtual string WriteFieldString(string name, string fieldName, string value, bool quote)
         {
+            value = value.Replace("\"", "\"\"");
             if (quote)
             { // quotes.
                 var valueBuilder = new StringBuilder();

--- a/src/GTFS/GTFSWriter.cs
+++ b/src/GTFS/GTFSWriter.cs
@@ -793,7 +793,7 @@ namespace GTFS
         /// <returns></returns>
         protected virtual string WriteFieldString(string name, string fieldName, string value, bool quote)
         {
-            value = value.Replace("\"", "\"\"");
+            value = value?.Replace("\"", "\"\"");
             if (quote)
             { // quotes.
                 var valueBuilder = new StringBuilder();


### PR DESCRIPTION
This commit prevents GTFS users from having to escape quotes in their
GTFS fields themselves, instead putting the onus on the library to
properly escape fields.  This matches the way commas in text fields are
currently handled.

Resolves #73.

Signed-off-by: Jeff Cuevas-Koch <jeff@cuevaskoch.com>